### PR TITLE
feat: Add option to get weather forecast for a chosen date and time

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -62,7 +62,7 @@ function App() {
         />
         <div className="Results">
           {!isLoaded && <h2>Loading...</h2>}
-          {isLoaded && results && (
+          {isLoaded && results && results.list && (
             <>
                 {results.list.map(item => {
                   if (item.dt_txt === dateTime) {

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ function App() {
 
   useEffect(() => {
     // make sure current time (minTimestamp) is up to date
-    setMinTimestamp(new Date().toISOString());
+    setMinTimestamp(new Date().toISOString().slice(0, 16));
 
     // get the last timestamp available (maxTimestamp) from the forecast endpoint
     fetch(

--- a/src/App.js
+++ b/src/App.js
@@ -11,80 +11,89 @@ function App() {
 
   useEffect(() => {
     if (dateTime !== "") {
-       fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&units=metric&dt=${dateTime}&appid=${process.env.REACT_APP_APIKEY}`)
-        .then(res => res.json())
+      fetch(
+        `https://api.openweathermap.org/data/2.5/weather?q=${city}&units=metric&dt=${dateTime}&appid=${process.env.REACT_APP_APIKEY}`
+      )
+        .then((res) => res.json())
         .then(
           (result) => {
-            setIsLoaded(true);
-            setResults(result);
-          },
-          (error) => {
-            setIsLoaded(true);
-            setError(error);
-          }
-        )
-    } else {
-      fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&units=metric&appid=${process.env.REACT_APP_APIKEY}`)
-        .then(res => res.json())
-        .then(
-          (result) => {
-            if (result['cod'] !== 200) {
-              setIsLoaded(false)
+            console.log(result);
+            if (result["cod"] !== 200) {
+              setIsLoaded(false);
             } else {
-              setIsLoaded(true);
               setResults(result);
+              setIsLoaded(true);
             }
           },
           (error) => {
             setIsLoaded(true);
             setError(error);
           }
-        )
+        );
+    } else {
+      fetch(
+        `https://api.openweathermap.org/data/2.5/weather?q=${city}&units=metric&appid=${process.env.REACT_APP_APIKEY}`
+      )
+        .then((res) => res.json())
+        .then(
+          (result) => {
+            console.log(result);
+            if (result["cod"] !== 200) {
+              setIsLoaded(false);
+            } else {
+              setResults(result);
+              setIsLoaded(true);
+            }
+          },
+          (error) => {
+            setIsLoaded(true);
+            setError(error);
+          }
+        );
     }
-  }, [city, dateTime])
+  }, [city, dateTime]);
 
   if (error) {
     return <div>Error: {error.message}</div>;
   } else {
-    return <>
-      <img className="logo" src={logo} alt="MLH Prep Logo"></img>
-      <div>
-        <h2>Enter a city below 👇</h2>
-        <input
-          type="text"
-          value={city}
-          onChange={event => setCity(event.target.value)} />
-        <h2>Select a date and time </h2>
-        <input
-          type="datetime-local"
-          value={dateTime}
-          onChange={event => setDateTime(event.target.value)}
-        />
-        <div className="Results">
-          {!isLoaded && <h2>Loading...</h2>}
-          {isLoaded && results && results.list && (
-            <>
-                {results.list.map(item => {
-                  if (item.dt_txt === dateTime) {
-                    return (
-                      <div key={item.dt}>
-                        <h3>{item.weather[0].main}</h3>
-                        <p>Feels like {item.main.feels_like}°C</p>
-                        <i><p>{results.city.name}, {results.city.country}</p></i>
-                      </div>
-                    );
-                  } else {
-                    return null;
-                  }
-                })}
-            </>
-          )}
-          {isLoaded && !results && (
-            <h2>No results found for {city} at {dateTime}</h2>
-          )}
+    return (
+      <>
+        <img className="logo" src={logo} alt="MLH Prep Logo"></img>
+        <div>
+          <h2>Enter a city below 👇</h2>
+          <input
+            type="text"
+            value={city}
+            onChange={(event) => setCity(event.target.value)}
+          />
+          <h2>Select a date and time </h2>
+          <input
+            type="datetime-local"
+            value={dateTime}
+            onChange={(event) => setDateTime(event.target.value)}
+          />
+          <div className="Results">
+            {!isLoaded && <h2>Loading...</h2>}
+            {isLoaded && results && (
+              <>
+                <h3>{results.weather[0].main}</h3>
+                <p>Feels like {results.main.feels_like}°C</p>
+                <i>
+                  <p>
+                    {results.name}, {results.sys.country}
+                  </p>
+                </i>
+              </>
+            )}
+            {isLoaded && !results && (
+              <h2>
+                No results found for {city} at {dateTime}
+              </h2>
+            )}
+          </div>
         </div>
-      </div>
-    </>
+      </>
+    );
   }
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,7 @@ function App() {
 
   useEffect(() => {
     if (dateTime !== "") {
-      fetch(`https://api.openweathermap.org/data/2.5/forecast?q=${city}&units=metric&dt=${dateTime}&appid=${process.env.REACT_APP_APIKEY}`)
+       fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&units=metric&dt=${dateTime}&appid=${process.env.REACT_APP_APIKEY}`)
         .then(res => res.json())
         .then(
           (result) => {

--- a/src/App.js
+++ b/src/App.js
@@ -67,7 +67,6 @@ function App() {
         .then((res) => res.json())
         .then(
           (result) => {
-            console.log(result);
             if (result["cod"] !== 200) {
               setIsLoaded(false);
             } else {

--- a/src/App.js
+++ b/src/App.js
@@ -6,26 +6,42 @@ function App() {
   const [error, setError] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
   const [city, setCity] = useState("New York City")
+  const [dateTime, setDateTime] = useState("");
   const [results, setResults] = useState(null);
 
   useEffect(() => {
-    fetch("https://api.openweathermap.org/data/2.5/weather?q=" + city + "&units=metric" + "&appid=" + process.env.REACT_APP_APIKEY)
-      .then(res => res.json())
-      .then(
-        (result) => {
-          if (result['cod'] !== 200) {
-            setIsLoaded(false)
-          } else {
+    if (dateTime !== "") {
+      fetch(`https://api.openweathermap.org/data/2.5/forecast?q=${city}&units=metric&dt=${dateTime}&appid=${process.env.REACT_APP_APIKEY}`)
+        .then(res => res.json())
+        .then(
+          (result) => {
             setIsLoaded(true);
             setResults(result);
+          },
+          (error) => {
+            setIsLoaded(true);
+            setError(error);
           }
-        },
-        (error) => {
-          setIsLoaded(true);
-          setError(error);
-        }
-      )
-  }, [city])
+        )
+    } else {
+      fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&units=metric&appid=${process.env.REACT_APP_APIKEY}`)
+        .then(res => res.json())
+        .then(
+          (result) => {
+            if (result['cod'] !== 200) {
+              setIsLoaded(false)
+            } else {
+              setIsLoaded(true);
+              setResults(result);
+            }
+          },
+          (error) => {
+            setIsLoaded(true);
+            setError(error);
+          }
+        )
+    }
+  }, [city, dateTime])
 
   if (error) {
     return <div>Error: {error.message}</div>;
@@ -38,14 +54,32 @@ function App() {
           type="text"
           value={city}
           onChange={event => setCity(event.target.value)} />
+        <h2>Select a date and time:</h2>
+        <input
+          type="datetime-local"
+          value={dateTime}
+          onChange={event => setDateTime(event.target.value)}
+        />
         <div className="Results">
           {!isLoaded && <h2>Loading...</h2>}
-          {console.log(results)}
-          {isLoaded && results && <>
-            <h3>{results.weather[0].main}</h3>
-            <p>Feels like {results.main.feels_like}°C</p>
-            <i><p>{results.name}, {results.sys.country}</p></i>
-          </>}
+          {isLoaded && results && (
+            <>
+              {results.list.map(item => {
+                if (item.dt_txt === dateTime) {
+                  return (
+                    <div key={item.dt}>
+                      <h3>{item.weather[0].main}</h3>
+                      <p>Feels like {item.main.feels_like}°C</p>
+                      <i><p>{results.city.name}, {results.city.country}</p></i>
+                    </div>
+                  );
+                }
+              })}
+            </>
+          )}
+          {isLoaded && !results && (
+            <h2>No results found for {city} at {dateTime}</h2>
+          )}
         </div>
       </div>
     </>

--- a/src/App.js
+++ b/src/App.js
@@ -54,7 +54,7 @@ function App() {
           type="text"
           value={city}
           onChange={event => setCity(event.target.value)} />
-        <h2>Select a date and time:</h2>
+        <h2>Select a date and time </h2>
         <input
           type="datetime-local"
           value={dateTime}

--- a/src/App.js
+++ b/src/App.js
@@ -64,17 +64,19 @@ function App() {
           {!isLoaded && <h2>Loading...</h2>}
           {isLoaded && results && (
             <>
-              {results.list.map(item => {
-                if (item.dt_txt === dateTime) {
-                  return (
-                    <div key={item.dt}>
-                      <h3>{item.weather[0].main}</h3>
-                      <p>Feels like {item.main.feels_like}°C</p>
-                      <i><p>{results.city.name}, {results.city.country}</p></i>
-                    </div>
-                  );
-                }
-              })}
+                {results.list.map(item => {
+                  if (item.dt_txt === dateTime) {
+                    return (
+                      <div key={item.dt}>
+                        <h3>{item.weather[0].main}</h3>
+                        <p>Feels like {item.main.feels_like}°C</p>
+                        <i><p>{results.city.name}, {results.city.country}</p></i>
+                      </div>
+                    );
+                  } else {
+                    return null;
+                  }
+                })}
             </>
           )}
           {isLoaded && !results && (


### PR DESCRIPTION
Added feature mentioned in Issue #3 

- Added a 'datetime-local' input for date and time, and as the user changes input, it updates the state of 'dateTime'
- Added dateTime state to the dependency array of useEffect, such that every time a user changes dateTime, forecast data from OpenWeather API is fetched
- Since the data returned is a list of forecasts within the next 5 days, the function 'getChosenForecast' was defined to only extract forecast data for the dateTime chosen by the user 
- Finally, we change the state of results with this forecast data 